### PR TITLE
[TENC-3383] [TP Lazada SDK] Replace getenv() to config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ composer require tendopay/tp-lazada-api
 
 You probably will need github token. See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token for reference.
 
+## Publish lazada config
+```bash
+php artisan vendor:publish --tag=lazada
+```
 
-## ENV variables
+## Set ENV variables in your application
 ```bash
 TP_LAZADA_APP_KEY=
 TP_LAZADA_APP_SECRET=
+TP_LAZADA_CALLBACK_URL=
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,13 @@
             "role": "Developer"
         }
     ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "TendoPay\\LazadaApi\\Providers\\LazadaServiceProvider"
+            ]
+        }
+    },
     "require": {
         "php": ">=7.4",
         "guzzlehttp/guzzle": "^7.0.1"

--- a/src/LazadaApi.php
+++ b/src/LazadaApi.php
@@ -14,8 +14,8 @@ final class LazadaApi
 
     public function __construct()
     {
-        $this->appKey = getenv('TP_LAZADA_APP_KEY');
-        $this->appSecret = getenv('TP_LAZADA_APP_SECRET');
-        $this->callbackUrl = getenv('TP_LAZADA_CALLBACK_URL');
+        $this->appKey = config('lazada.api_key');
+        $this->appSecret = config('lazada.api_secret');
+        $this->callbackUrl = config('lazada.callback_url');
     }
 }

--- a/src/Providers/LazadaServiceProvider.php
+++ b/src/Providers/LazadaServiceProvider.php
@@ -13,7 +13,8 @@ class LazadaServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/lazada.php', 'lazada'
+            __DIR__ . '/../config/lazada.php',
+            'lazada'
         );
     }
 

--- a/src/Providers/LazadaServiceProvider.php
+++ b/src/Providers/LazadaServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TendoPay\LazadaApi\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class LazadaServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../config/lazada.php' => config_path('lazada.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/lazada.php', 'lazada'
+        );
+    }
+
+    public function register()
+    {
+    }
+}

--- a/src/Providers/LazadaServiceProvider.php
+++ b/src/Providers/LazadaServiceProvider.php
@@ -10,7 +10,7 @@ class LazadaServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/lazada.php' => config_path('lazada.php'),
-        ], 'config');
+        ], 'lazada');
 
         $this->mergeConfigFrom(
             __DIR__ . '/../config/lazada.php', 'lazada'

--- a/src/config/lazada.php
+++ b/src/config/lazada.php
@@ -1,6 +1,7 @@
 <?php
+
 return [
     'api_key' => env('TP_LAZADA_APP_KEY'),
     'api_secret' => env('TP_LAZADA_APP_SECRET'),
-    'callback_url' => env('TP_LAZADA_CALLBACK_URL')
+    'callback_url' => env('TP_LAZADA_CALLBACK_URL'),
 ];

--- a/src/config/lazada.php
+++ b/src/config/lazada.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'api_key' => env('TP_LAZADA_APP_KEY'),
+    'api_secret' => env('TP_LAZADA_APP_SECRET'),
+    'callback_url' => env('TP_LAZADA_CALLBACK_URL')
+];


### PR DESCRIPTION
# QA GUIDE (install in core app for testing purposes)
1. For test purposes, please use proper branch in composer.json in core app
`"tendopay/tp-lazada-api": "dev-feature/TENC-3383"`

2. Clear cache
`composer clear-cache`

3. Update package to TEST version
`composer update`

4. Publish config file
`php artisan vendor:publish --tag=lazada`

# For core (live version) after merged
1. Clear cache
`composer clear-cache`

2. Update package to latest version after merge
`composer update`

3. Publish file and latest composer.json file

# Tests result
![image](https://github.com/user-attachments/assets/0ca18331-6ea3-487c-9ff3-0e98ee24bce9)
![image](https://github.com/user-attachments/assets/8d428cda-491a-4670-a429-d71918c4d511)

file lazada.php should be copied to config/lazada.php, then env variables can be used as in core app.
